### PR TITLE
mod.json has duplicated variable name?

### DIFF
--- a/mod.json
+++ b/mod.json
@@ -11,7 +11,7 @@
     "Settings": {
         "Debug" : true,
         "LightWingMonthlyCost" : 50000,
-        "LightWingMonthlyCost" : 75000,
+        "MediumWingMonthlyCost" : 75000,
         "HeavyWingMonthlyCost" : 100000,
         "LeopardRepairCostPerDamage" : 100
     }


### PR DESCRIPTION
Light wing cost defined twice, medium wing cost not defined.